### PR TITLE
Added a test to show issue with JCROM child loading

### DIFF
--- a/jcr-test/src/main/configuration/application.conf
+++ b/jcr-test/src/main/configuration/application.conf
@@ -19,7 +19,7 @@ monitor.jmx.enabled=true
 
 
 jcrom {
-    packages=["org.wisdom.jcrom.entity1", "org.wisdom.jcrom.entity2"]
+    packages=["org.wisdom.jcrom.entity1", "org.wisdom.jcrom.entity2", "org.wisdom.jcrom.dummy"]
     dynamic.instantiation = true
     create.path = true
     dev.repository = cloud-repository-test

--- a/jcr-test/src/main/configuration/cnd/test.cnd
+++ b/jcr-test/src/main/configuration/cnd/test.cnd
@@ -3,3 +3,5 @@
 [test:hello] > nt:unstructured
 [test:world] > nt:unstructured
 [test:testentity] > nt:unstructured
+[test:baby] > nt:unstructured
+[test:daddy] > nt:unstructured

--- a/jcr-test/src/test/java/org/wisdom/jcrom/MultiPackageIT.java
+++ b/jcr-test/src/test/java/org/wisdom/jcrom/MultiPackageIT.java
@@ -71,7 +71,7 @@ public class MultiPackageIT extends WisdomTest {
     public void multiPackage() {
         osgi.waitForService(Crud.class, null, 5000);
         final List<Crud> cruds = osgi.getServiceObjects(Crud.class);
-        Assert.assertEquals(2, cruds.size());
+        Assert.assertEquals(4, cruds.size());
     }
 
 }

--- a/jcr-test/src/test/java/org/wisdom/jcrom/OSGiUtils.java
+++ b/jcr-test/src/test/java/org/wisdom/jcrom/OSGiUtils.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2015 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.wisdom.jcrom;
 
 import org.junit.Assert;

--- a/jcr-test/src/test/java/org/wisdom/jcrom/SaveAndReloadIT.java
+++ b/jcr-test/src/test/java/org/wisdom/jcrom/SaveAndReloadIT.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2015 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wisdom.jcrom;
+
+import javax.inject.Inject;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.ow2.chameleon.testing.helpers.OSGiHelper;
+import org.wisdom.api.model.Crud;
+import org.wisdom.jcrom.dummy.Baby;
+import org.wisdom.jcrom.dummy.Daddy;
+import org.wisdom.test.parents.WisdomTest;
+
+public class SaveAndReloadIT extends WisdomTest {
+
+	private static final String DADDY_PATH = "/daddies";
+	private static final String DADDY_NAME = "pops";
+	private static final String BABY_PATH = "/baby";
+	private static final String BABY_NAME = "junior";
+
+	@Inject
+	BundleContext context;
+
+	OSGiHelper osgi;
+
+	OSGiUtils osGiUtils;
+
+	@Before
+	public void setUp() throws InvalidSyntaxException, InterruptedException {
+		osgi = new OSGiHelper(context);
+		osGiUtils = new OSGiUtils(osgi);
+	}
+
+	@Test
+	public void saveThenReload() {
+		Baby baby = new Baby();
+		baby.setPath(BABY_PATH);
+		baby.setName(BABY_NAME);
+		Assert.assertTrue(baby.isSucking());
+
+		Crud<Baby, String> crud = osGiUtils.getCrud(Baby.class);
+		crud.save(baby);
+
+		Baby loadedBaby = crud.findOne(BABY_NAME);
+		Assert.assertTrue(loadedBaby.isSucking());
+		loadedBaby.setSucking(false);
+		crud.save(loadedBaby);
+		
+		Baby reloadedBaby = crud.findOne(BABY_NAME);
+		Assert.assertFalse(reloadedBaby.isSucking());
+	}
+	
+	@Test
+	public void saveThenReloadViaParent() {
+		Daddy daddy = new Daddy();
+		daddy.setPath(DADDY_PATH);
+		daddy.setName(DADDY_NAME);
+		Baby baby = new Baby();
+		baby.setName(BABY_NAME);
+		baby.setPath(DADDY_PATH + BABY_PATH);
+		daddy.setBaby(baby);
+		Assert.assertTrue(baby.isSucking());
+		
+		Crud<Daddy, String> dadCrud = osGiUtils.getCrud(Daddy.class);
+		daddy = dadCrud.save(daddy);
+		
+		Crud<Baby, String> kidCrud = osGiUtils.getCrud(Baby.class);
+		Baby foundBaby = kidCrud.findOne(baby.getName());
+		foundBaby.setSucking(false);
+		kidCrud.save(foundBaby);
+		
+		Daddy foundDad = dadCrud.findOne(daddy.getName());
+		Assert.assertFalse("This baby sucks!", foundDad.getBaby().isSucking());
+	}
+}

--- a/jcr-test/src/test/java/org/wisdom/jcrom/dummy/Baby.java
+++ b/jcr-test/src/test/java/org/wisdom/jcrom/dummy/Baby.java
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2015 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wisdom.jcrom.dummy;
+
+import org.jcrom.AbstractJcrEntity;
+import org.jcrom.annotations.JcrNode;
+import org.jcrom.annotations.JcrProperty;
+
+@JcrNode(nodeType = "test:baby")
+public class Baby extends AbstractJcrEntity {
+	private static final long serialVersionUID = 1L;
+	
+	@JcrProperty
+	private boolean sucking = true;
+
+	public boolean isSucking() {
+		return sucking;
+	}
+
+	public void setSucking(boolean sucking) {
+		this.sucking = sucking;
+	}
+}

--- a/jcr-test/src/test/java/org/wisdom/jcrom/dummy/Daddy.java
+++ b/jcr-test/src/test/java/org/wisdom/jcrom/dummy/Daddy.java
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2015 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wisdom.jcrom.dummy;
+
+import org.jcrom.AbstractJcrEntity;
+import org.jcrom.annotations.JcrChildNode;
+import org.jcrom.annotations.JcrNode;
+
+@JcrNode(nodeType = "test:daddy")
+public class Daddy extends AbstractJcrEntity {
+	private static final long serialVersionUID = 1L;
+
+	@JcrChildNode
+	private Baby baby;
+
+	public Baby getBaby() {
+		return baby;
+	}
+
+	public void setBaby(Baby baby) {
+		this.baby = baby;
+	}
+}


### PR DESCRIPTION
This test is to illustrate a problem we've been having with wisdom-jcr.
When we use a Crud to save a child entity, then load the parent entity, accessing the child through the parent does not reflect the changes that were made.
