### PR TITLE
Add a light read-only JCR web explorer module (#15)

### DIFF
--- a/modeshape-sample/pom.xml
+++ b/modeshape-sample/pom.xml
@@ -48,17 +48,22 @@
             <artifactId>wisdom-monitor</artifactId>
             <version>${wisdom.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wisdom-framework.jcr</groupId>
+            <artifactId>wisdom-jcr-web-explorer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- wisdom-jcr -->
         <dependency>
             <groupId>org.wisdom-framework.jcr</groupId>
             <artifactId>wisdom-modeshape</artifactId>
-            <version>${wisdom.jcr.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wisdom-framework.jcr</groupId>
             <artifactId>wisdom-jcr-core</artifactId>
-            <version>${wisdom.jcr.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -70,7 +75,6 @@
             <artifactId>jcrom</artifactId>
             <version>${jcrom.version}</version>
         </dependency>
-        <!-- /wisdom-jcr -->
     </dependencies>
 
     <dependencyManagement>

--- a/modeshape-sample/src/main/java/todo/controllers/TodoController.java
+++ b/modeshape-sample/src/main/java/todo/controllers/TodoController.java
@@ -21,15 +21,20 @@ package todo.controllers;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.felix.ipojo.annotations.Requires;
 import org.apache.felix.ipojo.annotations.Validate;
 import org.wisdom.api.DefaultController;
 import org.wisdom.api.annotations.*;
 import org.wisdom.api.http.Result;
 import org.wisdom.api.model.Crud;
 import org.wisdom.api.model.HasBeenRollBackException;
+import org.wisdom.jcrom.runtime.JcrRepository;
+import org.wisdom.jcrom.runtime.JcrTools;
 import todo.models.Todo;
 import todo.models.TodoList;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 import javax.validation.Valid;
 import java.util.Iterator;
 import java.util.UUID;
@@ -45,6 +50,9 @@ public class TodoController extends DefaultController {
 
     @Model(Todo.class)
     private Crud<Todo, String> todoCrud;
+
+    @Requires
+    private JcrRepository jcrRepository;
 
 
     @Validate
@@ -65,6 +73,14 @@ public class TodoController extends DefaultController {
             list.setOwner("foo");
             listCrud.save(list);
 
+            try {
+                Node node = jcrRepository.getSession().getNode(todo.getPath());
+                JcrTools.registerAndAddMixinType(jcrRepository.getSession(), node, "Mixin 1");
+                JcrTools.registerAndAddMixinType(jcrRepository.getSession(), node, "Mixin 2");
+                JcrTools.registerAndAddMixinType(jcrRepository.getSession(), node, "Mixin 3");
+            } catch (RepositoryException e) {
+                logger().error(e.getMessage(), e);
+            }
 
             logger().info("Item added:");
             logger().info("todo : {} - {}", todo, todo.getId());

--- a/modeshape-sample/src/main/java/todo/models/Todo.java
+++ b/modeshape-sample/src/main/java/todo/models/Todo.java
@@ -75,4 +75,12 @@ public class Todo {
     public void setId(String id) {
         this.id = id;
     }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-framework</artifactId>
-        <version>0.9.1</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.wisdom-framework.jcr</groupId>
@@ -23,8 +23,9 @@
     <modules>
         <module>wisdom-jcr-core</module>
         <module>wisdom-modeshape</module>
-        <module>modeshape-sample</module>
         <module>wisdom-modeshape-web-jcr-rest</module>
+        <module>wisdom-jcr-web-explorer</module>
+        <module>modeshape-sample</module>
         <module>jcr-test</module>
     </modules>
 
@@ -42,13 +43,12 @@
     </scm>
 
     <properties>
-        <wisdom.version>0.9.1</wisdom.version>
+        <wisdom.version>0.10.0-SNAPSHOT</wisdom.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <modeshape.version>4.2.0.Final</modeshape.version>
         <jcrom.version>2.1.0</jcrom.version>
         <jettison.version>1.3.1</jettison.version>
-        <wisdom.jcr.version>1.0-SNAPSHOT</wisdom.jcr.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/wisdom-jcr-core/src/main/java/org/wisdom/jcrom/runtime/JcrTools.java
+++ b/wisdom-jcr-core/src/main/java/org/wisdom/jcrom/runtime/JcrTools.java
@@ -19,41 +19,21 @@
  */
 package org.wisdom.jcrom.runtime;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import javax.jcr.Binary;
-import javax.jcr.ImportUUIDBehavior;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
-import javax.jcr.PropertyType;
-import javax.jcr.Repository;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
+import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeDefinition;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.jcr.observation.Event;
 import javax.jcr.observation.EventIterator;
 import javax.jcr.observation.EventListener;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
+import java.io.*;
+import java.net.URL;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /*
  * ModeShape (http://www.modeshape.org)
@@ -998,4 +978,37 @@ public class JcrTools {
         }
     }
 
+    /**
+     * Register new mixin type if does not exists on workspace
+     *
+     * @param session the JCR session
+     * @param mixin the mixin name to register
+     * @throws RepositoryException
+     */
+    public static void registerMixinType(Session session, String mixin) throws RepositoryException {
+        NodeTypeManager nodeTypeManager = session.getWorkspace().getNodeTypeManager();
+        if (!nodeTypeManager.hasNodeType(mixin)) {
+            NodeTypeTemplate nodeTypeTemplate = nodeTypeManager.createNodeTypeTemplate();
+            nodeTypeTemplate.setMixin(true);
+            nodeTypeTemplate.setName(mixin);
+
+            NodeTypeDefinition[] nodeTypes = new NodeTypeDefinition[]{nodeTypeTemplate};
+            nodeTypeManager.registerNodeTypes(nodeTypes, true);
+        }
+    }
+
+    /**
+     * Register new mixin type if does not exists on workspace the add it to the given node
+     *
+     * @param session the JCR session
+     * @param node the node where to add the mixin
+     * @param mixin the mixin name to add
+     * @throws RepositoryException
+     */
+    public static void registerAndAddMixinType(Session session, Node node, String mixin) throws RepositoryException {
+        registerMixinType(session, mixin);
+        if (!Arrays.asList(node.getMixinNodeTypes()).contains(mixin)) {
+            node.addMixin(mixin);
+        }
+    }
 }

--- a/wisdom-jcr-web-explorer/pom.xml
+++ b/wisdom-jcr-web-explorer/pom.xml
@@ -3,50 +3,36 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.wisdom-framework.jcr</groupId>
         <artifactId>wisdom-jcr</artifactId>
+        <groupId>org.wisdom-framework.jcr</groupId>
         <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>wisdom-jcr-core</artifactId>
+    <artifactId>wisdom-jcr-web-explorer</artifactId>
 
     <packaging>wisdom</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.wisdom-framework</groupId>
-            <artifactId>wisdom-api</artifactId>
+            <artifactId>wisdom-monitor</artifactId>
             <version>${wisdom.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
-            <version>${ipojo.version}</version>
+            <groupId>org.wisdom-framework.jcr</groupId>
+            <artifactId>wisdom-jcr-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jcrom</groupId>
-            <artifactId>jcrom</artifactId>
-            <version>${jcrom.version}</version>
-        </dependency>
-        <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>wisdom-test</artifactId>
-            <version>${wisdom.version}</version>
-        </dependency>
-        <dependency>
-            <!-- slf4j binding used for tests -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jcl</artifactId>
-            <version>1.7.6</version>
-            <scope>test</scope>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr</artifactId>
+            <version>${modeshape.version}</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -84,5 +70,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/wisdom-jcr-web-explorer/src/main/java/org/wisdom/monitor/extensions/jcr/JcrExplorerExtension.java
+++ b/wisdom-jcr-web-explorer/src/main/java/org/wisdom/monitor/extensions/jcr/JcrExplorerExtension.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2015 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wisdom.monitor.extensions.jcr;
+
+import org.apache.felix.ipojo.annotations.Requires;
+import org.wisdom.api.DefaultController;
+import org.wisdom.api.annotations.*;
+import org.wisdom.api.http.HttpMethod;
+import org.wisdom.api.http.Result;
+import org.wisdom.api.security.Authenticated;
+import org.wisdom.api.templates.Template;
+import org.wisdom.jcrom.runtime.JcrRepository;
+import org.wisdom.monitor.service.MonitorExtension;
+
+import javax.jcr.Node;
+
+/**
+ * Created by Vianney on 27/11/2015.
+ */
+@Controller
+@Path("/monitor/jcr/explorer")
+@Authenticated("Monitor-Authenticator")
+public class JcrExplorerExtension extends DefaultController implements MonitorExtension {
+
+    @View("monitor/explorer")
+    Template explorer;
+
+    @Requires
+    JcrRepository jcrRepository;
+
+    @Route(method = HttpMethod.GET, uri = "{path*}")
+    public Result explorer(@Parameter("path") String path) throws Exception {
+        path = path.isEmpty() ? "/" : path;
+        Node node = jcrRepository.getSession().getNode(path);
+
+        JcrExplorerModel jcrExplorerModel = JcrExplorerModel.build(node);
+        return ok(render(explorer, "nodeModel", jcrExplorerModel, "repository", jcrRepository));
+    }
+
+    @Override
+    public String label() {
+        return "Explorer";
+    }
+
+    @Override
+    public String url() {
+        return "/monitor/jcr/explorer";
+    }
+
+    @Override
+    public String category() {
+        return "JCR";
+    }
+}

--- a/wisdom-jcr-web-explorer/src/main/java/org/wisdom/monitor/extensions/jcr/JcrExplorerModel.java
+++ b/wisdom-jcr-web-explorer/src/main/java/org/wisdom/monitor/extensions/jcr/JcrExplorerModel.java
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2015 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wisdom.monitor.extensions.jcr;
+
+import javax.jcr.*;
+import javax.jcr.nodetype.NodeType;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Vianney on 27/11/2015.
+ */
+public class JcrExplorerModel {
+
+    private Node node;
+    private List<Node> subnodes = new ArrayList<>();
+    private Map<String, String> properties = new HashMap<>();
+    private List<String> mixins = new ArrayList<>();
+
+    public static JcrExplorerModel build(Node node) throws Exception {
+        return new JcrExplorerModel(node);
+    }
+
+    private JcrExplorerModel(Node node) throws RepositoryException {
+        this.node = node;
+        buildSubNodes();
+        buildProperties();
+        buildMixins();
+    }
+
+    public Node getNode() {
+        return node;
+    }
+
+    public List<Node> getSubnodes() {
+        return subnodes;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public List<String> getMixins() {
+        return mixins;
+    }
+
+    private void buildSubNodes() throws RepositoryException {
+        NodeIterator nodeIterator = node.getNodes();
+        while (nodeIterator.hasNext()) {
+            Node nextNode = nodeIterator.nextNode();
+            subnodes.add(nextNode);
+        }
+    }
+
+    private void buildProperties() throws RepositoryException {
+        PropertyIterator propertyIterator = node.getProperties();
+        while (propertyIterator.hasNext()) {
+            Property property = propertyIterator.nextProperty();
+            if (!node.getPrimaryNodeType().isNodeType("nt:resource") || !property.getName().equals("jcr:data")) {
+                properties.put(property.getName(), getPropertyValue(property));
+            }
+        }
+    }
+
+    private void buildMixins() throws RepositoryException {
+        for (NodeType nodeType : node.getMixinNodeTypes()) {
+            mixins.add(nodeType.getName());
+        }
+    }
+
+    private String getPropertyValue(Property property) {
+        try {
+            String result = "";
+            if (!property.isMultiple()) {
+                result += showProperly(property.getValue());
+            } else {
+                for (Value value : property.getValues()) {
+                    result += showProperly(value) + " - ";
+                }
+                result = result.substring(0, result.lastIndexOf(" - "));
+            }
+
+            return result;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String showProperly(Value value) throws RepositoryException, IOException, ClassNotFoundException {
+        if (value.getType() == PropertyType.BINARY) {
+            return new ObjectInputStream(value.getBinary().getStream()).readObject().toString();
+        }
+        return value.getString();
+    }
+}

--- a/wisdom-jcr-web-explorer/src/main/resources/templates/monitor/explorer.thl.html
+++ b/wisdom-jcr-web-explorer/src/main/resources/templates/monitor/explorer.thl.html
@@ -1,0 +1,119 @@
+<!--
+  #%L
+  Wisdom-Framework
+  %%
+  Copyright (C) 2013 - 2015 Wisdom Framework
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<!DOCTYPE html>
+<html layout:decorator="layout">
+    <head lang="en">
+        <title>JCR web explorer</title>
+
+        <link rel="stylesheet" href="/assets/table.css"/>
+        <link href="/assets/dashboard.css" rel="stylesheet"/>
+        <style>
+            ul {
+                margin: 0px;
+            }
+        </style>
+    </head>
+    <body>
+        <div layout:fragment="content">
+            <!-- the actual content goes there -->
+
+            <h1 class="page-header">Repository explorer</h1>
+
+            <div class="container">
+                <div class="col-md-10">
+                    <div class="row">
+                        <table class="table table-striped table-condensed">
+                            <thead>
+                                <tr>
+                                    <th class="col-md-2"></th>
+                                    <th class="col-md-7"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Repository name</td>
+                                    <td th:text="${repository.getName()}"></td>
+                                </tr>
+                                <tr>
+                                    <td>Node name</td>
+                                    <td th:text="${nodeModel.getNode().getName()}"></td>
+                                </tr>
+                                <tr>
+                                    <td>Node path</td>
+                                    <td>
+                                        <a th:href="@{~/monitor/jcr/explorer/}">/</a>
+                                        <a th:each="nodeName : ${#strings.listSplit(nodeModel.getNode().getPath(),'/')}"
+                                           th:text="|${nodeName} /|"
+                                           th:href="@{~/monitor/jcr/explorer{path}(path=|${#strings.substringBefore(nodeModel.getNode().getPath(),nodeName)}${nodeName}|)}">
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Primary type</td>
+                                    <td th:text="${nodeModel.getNode().getPrimaryNodeType().getName()}">primary-type</td>
+                                </tr>
+                                <tr>
+                                    <td>Registered mixins</td>
+                                    <td>
+                                        <ul class="list-unstyled" th:each="mixin : ${nodeModel.mixins}">
+                                            <li th:text="${mixin}">Mixin name</li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="row">
+                        <h2>Direct subnodes</h2>
+                        <table class="table table-striped table-condensed">
+                            <thead>
+                                <th>Name</th>
+                            </thead>
+                            <tbody>
+                                <tr th:each="node: ${nodeModel.subnodes}">
+                                    <td>
+                                        <a th:text="${node.getName()}" th:href="@{~/monitor/jcr/explorer{path}(path=${node.getPath()})}">path</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="row">
+                        <h2>Properties</h2>
+                        <table class="table table-striped table-condensed">
+                            <thead>
+                                <th>Name</th>
+                                <th>Value</th>
+                            </thead>
+                            <tbody>
+                                <tr th:each="property : ${nodeModel.properties}">
+                                    <td th:text="${property.key}">name</td>
+                                    <td th:text="${property.value}">value</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This is a first version of a simple JCR web explorer. It allows to navigate upon the JCR graph provided by the JcrRepository and displays some informations about the current node:
- name and path
- mixins
- subnodes
- properties

All nodes can be accessed through is path in the url.
At a moment this explorer is read-only.

This explorer is provided as an extension of the wisdom-monitor bundle. To use it in your wisdom-project, simply add the follwing dependency:

```
<dependency>
    <groupId>org.wisdom-framework.jcr</groupId>
    <artifactId>wisdom-jcr-web-explorer</artifactId>
    <version>${wisdom-jcr.version}<version>
</dependency>
```
