### PR TITLE
Upgrade modeshape version to 4.5.0.Final

### DIFF
--- a/jcr-test/pom.xml
+++ b/jcr-test/pom.xml
@@ -115,6 +115,7 @@
                             <include>org.modeshape:modeshape-common</include>
                             <include>joda-time:joda-time</include>
                             <include>org.jcrom:jcrom</include>
+                            <include>org.apache.tika:tika-core</include>
                         </includes>
                         <excludeFromApplication>true</excludeFromApplication>
                     </libraries>

--- a/modeshape-sample/pom.xml
+++ b/modeshape-sample/pom.xml
@@ -74,6 +74,12 @@
             <groupId>org.jcrom</groupId>
             <artifactId>jcrom</artifactId>
             <version>${jcrom.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -100,11 +106,10 @@
                 <configuration>
                     <libraries>
                         <includes>
-                            <!-- wisdom-jcr -->
                             <include>org.modeshape:modeshape-jcr</include>
                             <include>joda-time:joda-time</include>
                             <include>org.jcrom:jcrom</include>
-                            <!-- /wisdom-jcr -->
+                            <include>org.apache.tika:tika-core</include>
                         </includes>
                         <excludeFromApplication>true</excludeFromApplication>
                     </libraries>

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,12 @@
         <wisdom.version>0.10.0-SNAPSHOT</wisdom.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <modeshape.version>4.2.0.Final</modeshape.version>
+        <modeshape.version>4.5.0.Final</modeshape.version>
         <jcrom.version>2.1.0</jcrom.version>
         <jettison.version>1.3.1</jettison.version>
+        <tika.version>1.9</tika.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -65,6 +67,11 @@
                         <artifactId>stax-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-core</artifactId>
+                <version>${tika.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/wisdom-jcr-core/pom.xml
+++ b/wisdom-jcr-core/pom.xml
@@ -28,6 +28,16 @@
             <groupId>org.jcrom</groupId>
             <artifactId>jcrom</artifactId>
             <version>${jcrom.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
         </dependency>
         <!-- Test dependencies -->
         <dependency>
@@ -46,7 +56,6 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -68,7 +77,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.wisdom-framework</groupId>
                 <artifactId>wisdom-maven-plugin</artifactId>
@@ -84,5 +92,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
Upgraded from 4.2.0. Due to incompatibilites with apache Tika dependencies (used in modeshape and jcrom) it was necessary to upgrade Tika to 1.9.0.

In futur developpements it will be necessary to update jcrom that is not seems to be maintened by his orignal owner. The forked project [JcromFX](https://github.com/dooApp/jcromfx) would be a good alternative.
